### PR TITLE
Fix global for register_application_commands

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1112,7 +1112,7 @@ class BotBase(GroupMixin):
 
     async def register_application_commands(
             self, commands: Optional[List[Union[Command, Group, ContextMenuCommand, ApplicationCommand]]] = MISSING,
-            *, guild: Optional[Guild]) -> List[ApplicationCommand]:
+            *, guild: Optional[Guild] = None) -> List[ApplicationCommand]:
         """|coro|
 
         Register the bot's commands as application commands. Providing ``None``


### PR DESCRIPTION
## Summary

Added missing None to the optional guild parameter in the register_application_commands method in the BotBase class to make it work for registering global application commands.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
