### PR TITLE
Don't default to 'code' as a response_type if nothing is passed in

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -273,7 +273,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    response_type: Optional[str] = "code",
+    response_type: Optional[str] = "",
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.


### PR DESCRIPTION
This causes a "missing redirect_uri in request" error when trying to invite the bot.
