### PR TITLE
Fixed typing error in move_to function of member

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -759,7 +759,7 @@ class Member(discord.abc.Messageable, _UserTag):
         else:
             await self._state.http.edit_my_voice_state(self.guild.id, payload)
 
-    async def move_to(self, channel: Union[VocalGuildChannel, None], *, reason: Optional[str] = None) -> None:
+    async def move_to(self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Moves a member to a new voice channel (they must be connected first).


### PR DESCRIPTION
I found a bug in the typing of this function:
```python
async def move_to(self, channel: VocalGuildChannel, *, reason: Optional[str] = None) -> None:
        """|coro|
        Moves a member to a new voice channel (they must be connected first).
        You must have the :attr:`~Permissions.move_members` permission to
        use this.
        This raises the same exceptions as :meth:`edit`.
        Parameters
        -----------
        channel: Optional[:class:`VoiceChannel`]
            The new voice channel to move the member to.
            Pass ``None`` to kick them from voice.
        reason: Optional[:class:`str`]
            The reason for doing this action. Shows up on the audit log.
        """
        await self.edit(voice_channel=channel, reason=reason)

```
The doctring says that this function can be used with `None` to kick from voice chat but the typing doesn't support it.