### PR TITLE
Add accessible utilities for timeouts

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -635,8 +635,8 @@ class Member(discord.abc.Messageable, _UserTag):
 
     async def disable_communication_until(
         self,
-        *,
         communication_disabled_until: datetime.datetime,
+        *,
         reason: Optional[str] = None,
     ) -> Member:
         r"""|coro|

--- a/discord/member.py
+++ b/discord/member.py
@@ -633,6 +633,45 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         await self.guild.kick(self, reason=reason)
 
+    async def disable_communication_until(
+        self,
+        *,
+        communication_disabled_until: datetime.datetime,
+        reason: Optional[str] = None,
+    ) -> Member:
+        r"""|coro|
+
+        Time this member out until a specific :class:`datetime.datetime`.
+
+        You must have the :attr:`~Permissions.moderate_members` permission to
+        use this, and the added :class:`Role`\s must appear lower in the list
+        of roles than the highest role of the member.
+
+        Parameters
+        -----------
+        communication_disabled_until: :class:`datetime.datetime`
+            The date at which to enable communication for this user again.
+        reason: Optional[:class:`str`]
+            The reason for this timeout. Shows up on the audit log.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to alter this member's communication.
+        HTTPException
+            Timeout failed.
+        """
+
+        # to avoid `member` being of type `Member | None`.
+        if TYPE_CHECKING:
+            member: Member
+        else:
+            member = await self.edit(
+                communication_disabled_until=communication_disabled_until,
+                reason=reason
+            )
+        return member
+
     async def disable_communication_for(
         self,
         *,

--- a/discord/member.py
+++ b/discord/member.py
@@ -694,8 +694,8 @@ class Member(discord.abc.Messageable, _UserTag):
                 "Disabled communication time must be greater than 0 seconds."
             )
 
+        # to avoid `member` being of type `Member | None`.
         if TYPE_CHECKING:
-            # `member` will always be a `Member` object here.
             member: Member
         else:
             member = await self.edit(
@@ -731,7 +731,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
 
         if TYPE_CHECKING:
-            # `member` will always be a `Member` object here.
+            # to avoid `member` being of type `Member | None`.
             member: Member
         else:
             member = await self.edit(

--- a/discord/member.py
+++ b/discord/member.py
@@ -42,6 +42,7 @@ from .permissions import Permissions
 from .enums import Status, try_enum
 from .colour import Colour
 from .object import Object
+from .errors import InvalidArgument
 
 __all__ = (
     'VoiceState',
@@ -632,7 +633,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         await self.guild.kick(self, reason=reason)
 
-    async def disable_communication(
+    async def disable_communication_for(
         self,
         *,
         seconds: int = 0,
@@ -690,7 +691,7 @@ class Member(discord.abc.Messageable, _UserTag):
         )
 
         if additional_time.total_seconds() <= 0:
-            raise ValueError(
+            raise InvalidArgument(
                 "Disabled communication time must be greater than 0 seconds."
             )
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -632,6 +632,114 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         await self.guild.kick(self, reason=reason)
 
+    async def disable_communication(
+        self,
+        *,
+        seconds: int = 0,
+        minutes: int = 0,
+        hours: int = 0,
+        days: int = 0,
+        weeks: int = 0,
+        reason: Optional[str] = None
+    ) -> Member:
+        r"""|coro|
+
+        Time this member out for a set amount of time.
+
+        You must have the :attr:`~Permissions.moderate_members` permission to
+        use this, and the added :class:`Role`\s must appear lower in the list
+        of roles than the highest role of the member.
+
+        .. note::
+
+            The time parameters are added up.
+
+        Parameters
+        -----------
+        seconds: :class:`int`
+            The amount of seconds to time out the member for.
+        minutes: :class:`int`
+            The amount of minutes to time out the member for. Multiplied by
+            60 when converted to seconds.
+        hours: :class:`int`
+            The amount of hours to time out the member for. Multiplied by
+            3,600 when converted to seconds.
+        days: :class:`int`
+            The amount of days to time out the member for. Multiplied by
+            86,400 when converted to seconds.
+        weeks: :class:`int`
+            The amount of weeks to time out the member for. Multiplied by
+            604,800 when converted to seconds.
+        reason: Optional[:class:`str`]
+            The reason for this timeout. Shows up on the audit log.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to alter this member's communication.
+        HTTPException
+            Timeout failed.
+        """
+
+        additional_time = datetime.timedelta(
+            days=days,
+            seconds=seconds,
+            minutes=minutes,
+            hours=hours,
+            weeks=weeks
+        )
+
+        if additional_time.total_seconds() <= 0:
+            raise ValueError(
+                "Disabled communication time must be greater than 0 seconds."
+            )
+
+        if TYPE_CHECKING:
+            # `member` will always be a `Member` object here.
+            member: Member
+        else:
+            member = await self.edit(
+                communication_disabled_until=utils.utcnow() + additional_time,
+                reason=reason
+            )
+        return member
+
+    async def enable_communication(
+        self,
+        *,
+        reason: Optional[str] = None
+    ) -> Member:
+        r"""|coro|
+
+        Revoke the communication timeout of this member.
+
+        You must have the :attr:`~Permissions.moderate_members` permission to
+        use this, and the added :class:`Role`\s must appear lower in the list
+        of roles than the highest role of the member.
+
+        Parameters
+        -----------
+        reason: Optional[:class:`str`]
+            The reason for this timeout. Shows up on the audit log.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to alter this member's communication.
+        HTTPException
+            Enabling communication failed.
+        """
+
+        if TYPE_CHECKING:
+            # `member` will always be a `Member` object here.
+            member: Member
+        else:
+            member = await self.edit(
+                communication_disabled_until=None,
+                reason=reason
+            )
+        return member
+
     async def edit(
         self,
         *,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds an accessible `disable_communication` and `enable_communication` coroutine to the `discord.Member` class, for putting bullies in the timeout zone, where they belong.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
