### PR TITLE
Fix Novus on Python 3.11

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -96,7 +96,7 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = field(default_factory=MISSING)
+    name: str = field(default_factory=lambda: MISSING)
     aliases: List[str] = field(default_factory=list)
     attribute: str = field(default_factory=lambda: MISSING)
     annotation: Any = field(default_factory=lambda: MISSING)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -96,13 +96,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = MISSING
+    name: str = field(default_factory=MISSING)
     aliases: List[str] = field(default_factory=list)
-    attribute: str = MISSING
-    annotation: Any = MISSING
-    default: Any = MISSING
-    max_args: int = MISSING
-    override: bool = MISSING
+    attribute: str = field(default_factory=MISSING)
+    annotation: Any = field(default_factory=MISSING)
+    default: Any = field(default_factory=MISSING)
+    max_args: int = field(default_factory=MISSING)
+    override: bool = field(default_factory=MISSING)
     cast_to_dict: bool = False
 
     @property

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -98,11 +98,11 @@ class Flag:
 
     name: str = field(default_factory=MISSING)
     aliases: List[str] = field(default_factory=list)
-    attribute: str = field(default_factory=MISSING)
-    annotation: Any = field(default_factory=MISSING)
-    default: Any = field(default_factory=MISSING)
-    max_args: int = field(default_factory=MISSING)
-    override: bool = field(default_factory=MISSING)
+    attribute: str = field(default_factory=lambda: MISSING)
+    annotation: Any = field(default_factory=lambda: MISSING)
+    default: Any = field(default_factory=lambda: MISSING)
+    max_args: int = field(default_factory=lambda: MISSING)
+    override: bool = field(default_factory=lambda: MISSING)
     cast_to_dict: bool = False
 
     @property


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR fixes Novus running on Python 3.11.0 by making use of `default_factory` for fields inside of `discord.ext.commands.flags.Flag`.
I tested this PR on Python 3.8.10, 3.9.13, 3.10.7 & 3.11.0 with the reproduction code from #61 and my bot (which is quite basic) and had no errors.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
