### PR TITLE
Optimize messages cache cleanup upon guild leave

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -1109,9 +1109,19 @@ class ConnectionState:
 
         # do a cleanup of the messages cache
         if self._messages is not None:
-            self._messages: Optional[Deque[Message]] = deque(
-                (msg for msg in self._messages if msg.guild != guild), maxlen=self.max_messages
-            )
+            to_delete: List[int] = []
+
+            idx: int
+            msg: Message
+
+            for idx, msg in enumerate(self._messages):
+                if msg.guild == guild:
+                    to_delete.append(idx)
+
+            del_idx: int
+
+            for del_idx in reversed(to_delete):
+                del self._messages[del_idx]
 
         self._remove_guild(guild)
         self.dispatch('guild_remove', guild)


### PR DESCRIPTION
Instead of recreating the `deque` in memory (previously), it should be modified in-place. This prevents potential "ghost references" to the old message cache. "Ghost references" could prevent the garbage collector from freeing the memory and thereby duplicating the message cache upon some guild leave events.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR is an attempt to fix a potential place in the code where there could be a memory leak. It is also good practice to not recreate a large block of memory again if it is not necessary.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
