### PR TITLE
Fix unsafe usage of assert

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -340,7 +340,8 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         Similar to :attr:`.Guild.me` except it may return the :class:`.ClientUser` in private message contexts.
         """
         try:
-            assert self.guild
+            if not self.guild:
+                raise AssertionError
             return self.guild.me
         except (AttributeError, AssertionError):
             return self.bot.user  # type: ignore - bot.user will never be None at this point.

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -82,7 +82,10 @@ class BucketType(Enum):
             return (msg.channel if isinstance(msg.channel, PrivateChannel) else msg.author.top_role).id  # type: ignore
 
     def _get_key_interaction(self, msg: Interaction) -> Any:
-        assert msg.user  # The user has to exist for slashies
+        # The user has to exist for slashies
+        if not msg.user:
+            raise AssertionError
+
         if self is BucketType.user:
             return msg.user.id
         elif self is BucketType.guild:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -984,7 +984,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                     break  # Just get the first param - deliberately shadow "name"
             else:
                 sig = self.clean_params[name]
-            assert sig
+
+            if not sig:
+                raise AssertionError
 
             # Get the converter
             converter = get_converter(sig)
@@ -1879,7 +1881,10 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
             if not c.application_command_meta:
                 continue
             a = c.to_application_command()
-            assert isinstance(a, discord.ApplicationCommandOption)
+
+            if not isinstance(a, discord.ApplicationCommandOption):
+                raise AssertionError
+
             command.add_option(a)
         return command
 

--- a/discord/ext/commands/http_interactions.py
+++ b/discord/ext/commands/http_interactions.py
@@ -137,9 +137,11 @@ def get_interaction_route_table(bot: BotBase, application_public_key: str, *, pa
             bot.dispatch('modal_submit', interaction)
         bot.dispatch("interaction", interaction)
 
+        if not isinstance(interaction.response, HTTPInteractionResponse):
+            raise AssertionError
+
         # Sleep for a couple seconds, just so we don't try and return without
         # sending a response from inside the bot
-        assert isinstance(interaction.response, HTTPInteractionResponse)
         t0 = time.time()
         while interaction.response._aiohttp_response._eof_sent is False and time.time() - t0 < SLEEP_TIME:
             await asyncio.sleep(0.01)

--- a/discord/ext/voice_recv/common/rtp.py
+++ b/discord/ext/voice_recv/common/rtp.py
@@ -54,7 +54,10 @@ def decode(data):
     # should always have 200-204 as their second byte, while RTP
     # packet are (probably) always 73 (or at least not 200-204).
 
-    assert data[0] >> 6 == 2 # check version bits
+    # check version bits
+    if not data[0] >> 6 == 2:
+        raise AssertionError
+
     return _rtcp_map.get(data[1], RTPPacket)(data)
 
 def is_rtcp(data):

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -1528,7 +1528,8 @@ class HTTPInteractionResponse(InteractionResponse):
             to_send = writer.buffer
             headers = payload.headers
 
-        assert to_send
+        if not to_send:
+            raise AssertionError
 
         self._aiohttp_response.headers.update(headers)
         await self._aiohttp_response.prepare(self._aiohttp_request)

--- a/discord/member.py
+++ b/discord/member.py
@@ -726,7 +726,10 @@ class Member(discord.abc.Messageable, _UserTag):
             communication_disabled_until=communication_disabled_until,
             reason=reason
         )
-        assert member
+
+        if not member:
+            raise AssertionError
+
         return member
 
     async def disable_communication_for(
@@ -788,7 +791,10 @@ class Member(discord.abc.Messageable, _UserTag):
             communication_disabled_until=utils.utcnow() + additional_time,
             reason=reason
         )
-        assert member
+
+        if not member:
+            raise AssertionError
+
         return member
 
     async def enable_communication(

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -802,7 +802,8 @@ class ThreadMember(Hashable):
         try:
             self.id = int(data['user_id'])
         except KeyError:
-            assert self._state.self_id is not None
+            if self._state.self_id is None:
+                raise AssertionError
             self.id = self._state.self_id
 
         try:


### PR DESCRIPTION
Statements with the `assert` keyword are removed when optimization is requested. This can cause unexpected behavior if the assertion is needed for safe/proper execution.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR attempts to add more stability to the library if optimization is requested when executing.

Reference:
- <https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement>

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
