### PR TITLE
Added aiohttp as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@
     dependencies = [
         "python-dotenv",
         "vf-flags>=0.2.0,<0.3",
+        "aiohttp>=3.8.0",
     ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements
 vf-flags>=0.2.0,<0.3
+aiohttp>=3.8.0,
 
 # Recommended
 python-dotenv


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

When building novus (and installing it), importing into a script would fail, if aiohttp wasnt installed (which it wasnt in my venv). Added aiohttp as a build dependency.

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
