### PR TITLE
Allow ApplicationCommandChoice value to be 0

### DIFF
--- a/novus/models/application_command.py
+++ b/novus/models/application_command.py
@@ -283,7 +283,7 @@ class ApplicationCommandChoice:
             *,
             name_localizations: LocType = None):
         self.name = name
-        self.value = value or name
+        self.value = value if value is not None else name
         self.name_localizations = flatten_localization(name_localizations)
 
     def _to_data(self) -> payloads.ApplicationCommandChoice:


### PR DESCRIPTION
## Summary

Originally, value = value or name would set the value to the name attribute if the value was 0. 

This change prevents that by explicitly checking if the value is None rather than 0.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
