### PR TITLE
Added "type" arg into config-dump docs

### DIFF
--- a/docs/exts/client/cli.rst
+++ b/docs/exts/client/cli.rst
@@ -20,7 +20,9 @@ or passed as a CLI arg).
 ---------------------
 
 Output a config (with arguments optionally supplied via CLI). This can be piped
-into a file (``novus config-dump --token test > config.yaml``).
+into a file (``novus config-dump --token [token] > config.yaml [type]``).
+
+Type is one of three: ``json``, ``yaml``, ``toml``. You'll need to install ``pyyaml`` if you plan to use yaml as type.
 
 ``novus new-plugin``
 --------------------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR updates the current docs for rewrite, adding the argument `[type]` into the `config-dump` command.
While it doesn't fix any issues, it does help understand that you have to specify a type for new people that tries using the command, instead of the previous command which didn't specify it, therefore resulting in the error `The following arguments are required: type`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)